### PR TITLE
Drop deprecated rc and runscript calls; use openrc/openrc-run

### DIFF
--- a/overlay-image-tools/etc/init.d/scw-hostname
+++ b/overlay-image-tools/etc/init.d/scw-hostname
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright (c) 2015 Scaleway <opensource@scaleway.com>
 # Released under the MIT license.
 

--- a/overlay-image-tools/etc/init.d/scw-initramfs-shutdown
+++ b/overlay-image-tools/etc/init.d/scw-initramfs-shutdown
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright (c) 2015 Scaleway <opensource@scaleway.com>
 # Released under the MIT license.
 

--- a/overlay-image-tools/etc/init.d/scw-ssh-keys
+++ b/overlay-image-tools/etc/init.d/scw-ssh-keys
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright (c) 2015 Scaleway <opensource@scaleway.com>
 # Released under the MIT license.
 

--- a/overlay-image-tools/etc/init.d/scw-sshd-keys
+++ b/overlay-image-tools/etc/init.d/scw-sshd-keys
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright (c) 2015 Scaleway <opensource@scaleway.com>
 # Released under the MIT license.
 

--- a/overlay-image-tools/etc/init.d/scw-swapfile
+++ b/overlay-image-tools/etc/init.d/scw-swapfile
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright (c) 2015 Scaleway <opensource@scaleway.com>
 # Released under the MIT license.
 

--- a/overlay-image-tools/etc/init.d/scw-sync-kernel-extra
+++ b/overlay-image-tools/etc/init.d/scw-sync-kernel-extra
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright (c) 2015 Scaleway <opensource@scaleway.com>
 # Released under the MIT license.
 

--- a/overlay/etc/init.d/update-motd
+++ b/overlay/etc/init.d/update-motd
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright (c) 2015 Scaleway <opensource@scaleway.com>
 # Released under the MIT license.
 

--- a/overlay/etc/inittab
+++ b/overlay/etc/inittab
@@ -1,8 +1,8 @@
 # /etc/inittab
 
-::sysinit:/sbin/rc sysinit
-::wait:/sbin/rc default
+::sysinit:/sbin/openrc sysinit
+::wait:/sbin/openrc default
 
 ::respawn:/usr/local/sbin/dynamic-getty
 
-::shutdown:/sbin/rc shutdown
+::shutdown:/sbin/openrc shutdown


### PR DESCRIPTION
Update shebang to /sbin/openrc-run in init scripts (https://bugs.gentoo.org/show_bug.cgi?id=494220) and openrc in inittab (https://bugs.gentoo.org/show_bug.cgi?id=493958).